### PR TITLE
allow nil chanDB

### DIFF
--- a/config_builder.go
+++ b/config_builder.go
@@ -830,12 +830,16 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 	}
 
 	startOpenTime := time.Now()
+	var chanDBBackend walletdb.DB
+	if d.chanDB != nil {
+		chanDBBackend = d.chanDB.Backend
+	}
 	databaseBackends, err := cfg.DB.GetBackends(
 		ctx, cfg.graphDatabaseDir(), cfg.networkDir, filepath.Join(
 			cfg.Watchtower.TowerDir,
 			cfg.registeredChains.PrimaryChain().String(),
 			lncfg.NormalizeNetwork(cfg.ActiveNetParams.Name),
-		), cfg.WtClient.Active, cfg.Watchtower.Active, d.chanDB.Backend,
+		), cfg.WtClient.Active, cfg.Watchtower.Active, chanDBBackend,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to obtain database "+


### PR DESCRIPTION
Fallback to default behavior when the chanDB is not supplied. This way it is possible to run this LND version standalone as well. Currently the program would panic with `invalid memory address or nil pointer dereference` because chanDB was nil. This simple check fixes that!