### PR TITLE
support returning incorrect details in interceptor

### DIFF
--- a/htlcswitch/interceptable_switch.go
+++ b/htlcswitch/interceptable_switch.go
@@ -538,6 +538,9 @@ func (f *interceptedForward) FailWithCode(code lnwire.FailCode) error {
 			OnionSHA256: shaOnionBlob(),
 		}
 
+	case lnwire.CodeIncorrectOrUnknownPaymentDetails:
+		failureMsg = &lnwire.FailIncorrectDetails{}
+
 	case lnwire.CodeTemporaryChannelFailure:
 		update := f.htlcSwitch.failAliasUpdate(
 			f.packet.incomingChanID, true,

--- a/lnrpc/routerrpc/forward_interceptor.go
+++ b/lnrpc/routerrpc/forward_interceptor.go
@@ -159,6 +159,9 @@ func (r *forwardInterceptor) resolveFromClient(
 		case lnrpc.Failure_INVALID_ONION_VERSION:
 			code = lnwire.CodeInvalidOnionVersion
 
+		case lnrpc.Failure_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS:
+			code = lnwire.CodeIncorrectOrUnknownPaymentDetails
+
 		// Default to TemporaryChannelFailure.
 		case 0, lnrpc.Failure_TEMPORARY_CHANNEL_FAILURE:
 			code = lnwire.CodeTemporaryChannelFailure


### PR DESCRIPTION
support returning incorrect_or_unknown_payment_details from the htlc interceptor. It was previously impossible to return this error from an intermediate node. This PR allows for that.