### PR TITLE
skip dustlimit check if reserve is 0

### DIFF
--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -509,7 +509,7 @@ func (r *ChannelReservation) validateReserveBounds() bool {
 		maxDustLimit = theirDustLimit
 	}
 
-	if theirDustLimit == 0 && theirRequiredReserve == 0 {
+	if theirRequiredReserve == 0 {
 		minChanReserve = ourRequiredReserve
 		maxDustLimit = ourDustLimit
 	}


### PR DESCRIPTION
This check fails for core lightning nodes.
They set a nonzero dustlimit when the reserve is zero.